### PR TITLE
Update pages_language_overlay.php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ sudo: false
 
 matrix:
   include:
-    - php: "7.0"
-      env: COVERAGE="NO" TYPO3_VERSION="^8.7"
     - php: "7.1"
       env: COVERAGE="YES" TYPO3_VERSION="^8.7"
     - php: "7.2"

--- a/Classes/Provider/PageProvider.php
+++ b/Classes/Provider/PageProvider.php
@@ -421,6 +421,9 @@ class PageProvider extends AbstractProvider implements ProviderInterface
         $records = [];
         while (0 < $record[$parentFieldName]) {
             $record = $this->recordService->getSingle($this->getTableName($record), '*', $record[$parentFieldName]);
+            if (!$record) {
+                break;
+            }
             $parentFieldName = $this->getParentFieldName($record);
             array_push($records, $record);
         }

--- a/Classes/Provider/PageProvider.php
+++ b/Classes/Provider/PageProvider.php
@@ -190,6 +190,9 @@ class PageProvider extends AbstractProvider implements ProviderInterface
         $action = $this->getControllerActionReferenceFromRecord($row) ?? 'default';
         $parts = explode('->', $action);
         $controllerActionName = end($parts);
+        if (empty($controllerActionName)) {
+            return 'default';
+        }
         $controllerActionName{0} = strtolower($controllerActionName{0});
         return $controllerActionName;
     }

--- a/Classes/Service/PageService.php
+++ b/Classes/Service/PageService.php
@@ -116,6 +116,9 @@ class PageService implements SingletonInterface
             'tx_fed_page_controller_action,' . $fieldList,
             $pageUid
         );
+        if (null === $page) {
+            return null;
+        }
 
         // Initialize with possibly-empty values and loop root line
         // to fill values as they are detected.
@@ -137,6 +140,10 @@ class PageService implements SingletonInterface
             // Note: 't3ver_oid' is analysed in order to make versioned records inherit the original record's
             // configuration as an emulated first parent page.
             $resolveParentPageUid = (integer) (0 > $page['pid'] ? $page['t3ver_oid'] : $page['pid']);
+            // Avoid useless SQL query if uid is 0, because uids in the database start from 1.
+            if (0 === $resolveParentPageUid) {
+                break;
+            }
             $page = $this->workspacesAwareRecordService->getSingle(
                 'pages',
                 $fieldList,

--- a/Configuration/TCA/Overrides/pages_language_overlay.php
+++ b/Configuration/TCA/Overrides/pages_language_overlay.php
@@ -13,6 +13,9 @@ if (TRUE === isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidpages']['setup']
             'label' => 'LLL:EXT:fluidpages/Resources/Private/Language/locallang.xlf:pages.tx_fed_page_flexform',
             'config' => [
                 'type' => 'flex',
+                'ds' => [
+                    'default' => '<T3DataStructure><ROOT><el></el></ROOT></T3DataStructure>'
+                ]
             ]
         ],
         'tx_fed_page_flexform_sub' => [
@@ -20,6 +23,9 @@ if (TRUE === isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidpages']['setup']
             'label' => 'LLL:EXT:fluidpages/Resources/Private/Language/locallang.xlf:pages.tx_fed_page_flexform_sub',
             'config' => [
                 'type' => 'flex',
+                'ds' => [
+                    'default' => '<T3DataStructure><ROOT><el></el></ROOT></T3DataStructure>'
+                ]                
             ]
         ],
     ]);

--- a/Tests/Unit/Service/PageServiceTest.php
+++ b/Tests/Unit/Service/PageServiceTest.php
@@ -62,7 +62,7 @@ class PageServiceTest extends AbstractTestCase
         }
         $instance = new PageService();
         $instance->injectWorkspacesAwareRecordService($service);
-        $result = $instance->getPageTemplateConfiguration(1);
+        $result = $instance->getPageTemplateConfiguration(2);
         $this->assertEquals($expected, $result);
     }
 
@@ -71,13 +71,17 @@ class PageServiceTest extends AbstractTestCase
      */
     public function getPageTemplateConfigurationTestValues()
     {
+        $u = 'uid';
+        $p = 'pid';
+        $o = 't3ver_oid';
         $m = 'tx_fed_page_controller_action';
         $s = 'tx_fed_page_controller_action_sub';
         return array(
-            array(array(array()), null),
-            array(array(array($m => '', $s => '')), null),
-            array(array(array($m => 'test1->test1', $s => 'test2->test2')), array($m => 'test1->test1', $s => 'test2->test2')),
-            array(array(array($m => ''), array($s => 'test2->test2')), array($m => 'test2->test2', $s => 'test2->test2'))
+            array(array(null), null),
+            array(array(array($u => 2, $p => 0, $o => 0, $m => '', $s => '')), null),
+            array(array(array($u => 2, $p => 0, $o => 0, $m => 'test1->test1', $s => 'test2->test2')), array($m => 'test1->test1', $s => 'test2->test2')),
+            array(array(array($u => 2, $p => 1, $o => 0, $m => ''), array($u => 1, $p => 0, $o => 0, $s => 'test2->test2')), array($m => 'test2->test2', $s => 'test2->test2')),
+            array(array(array($u => 2, $p => -1, $o => 1, $m => ''), array($u => 1, $p => 0, $o => 0, $s => 'test2->test2')), array($m => 'test2->test2', $s => 'test2->test2'))
         );
     }
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "typo3/cms-frontend": "^8.7 | ^9 | dev-master",
     "typo3/cms-recordlist": "^8.7 | ^9 | dev-master",
     "fluidtypo3/flux": "^9.0 | dev-development",
-    "php": ">=7.0.0"
+    "php": ">=7.1.0"
   },
   "type": "typo3-cms-extension",
   "keywords": [

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -25,7 +25,7 @@ $EM_CONF[$_EXTKEY] = array (
   array (
     'depends' => 
     array (
-      'php' => '7.0.0-7.2.99',
+      'php' => '7.1.0-7.2.99',
       'typo3' => '8.7.0-9.5.99',
       'flux' => '9.0.0-9.99.99',
     ),


### PR DESCRIPTION
Prevents the following Error in Backend:

#1463826960: TCA misconfiguration in table "pages_language_overlay" field "tx_fed_page_flexform" config section: The field is configured as type="flex" and no "ds_pointerField" is defined and "ds" is not an array. Either configure a default data structure in ['ds']['default'] or add a "ds_pointerField" lookup mechanism that specifies the data structure (More information)